### PR TITLE
Fix hero image visibility

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,9 +4,9 @@ export default function Home() {
   return (
     <>
       {/* HERO */}
-      <section className="relative h-screen flex flex-col justify-center overflow-hidden bg-loro-gradient">
+      <section className="relative h-screen flex flex-col justify-center overflow-hidden">
         {/* Background Image with parallax drift */}
-        <div className="absolute inset-0 -z-10 will-change-transform animate-pan-bg">
+        <div className="absolute inset-0 z-0 will-change-transform animate-pan-bg">
           <Image
             src="/images/hero/winecountry.jpg"
             alt="Wine country estate with architectural cast stone elements"


### PR DESCRIPTION
## Summary
- Fixed hero image being hidden behind opaque background gradient
- Removed `bg-loro-gradient` and changed `-z-10` to `z-0` on the image container

## Test plan
- [ ] Verify hero image (fireplace couple) is visible on landing page

🤖 Generated with [Claude Code](https://claude.com/claude-code)